### PR TITLE
require yaml in fetcher

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -5,6 +5,7 @@ require "cgi"
 require "securerandom"
 require "zlib"
 require "rubygems/request"
+require "yaml"
 
 module Bundler
   # Handles all the fetching with the rubygems server


### PR DESCRIPTION
This is needed to parse some gemspecs.  See #5405

## What was the end-user or developer problem that led to this PR?

See #5405.  When using --full-index, I came across a gem that couldn't be parsed because the gem had a YAML object in it.

## What is your fix for the problem, implemented in this PR?

require yaml to grant access to the yaml file

## Make sure the following tasks are checked

- [ x] Describe the problem / feature
- [ x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ x] Write code to solve the problem
- [ x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
